### PR TITLE
Fix typo in production cost data source

### DIFF
--- a/itwm_example/production_cost_data_source/production_cost_data_source.py
+++ b/itwm_example/production_cost_data_source/production_cost_data_source.py
@@ -13,7 +13,7 @@ class ProductionCostDataSource(BaseDataSource):
         cost = reaction_time * (temperature - 290)**2 * model.W
         cost_gradient = [
                 reaction_time * (2 * temperature - 2 * 290) * model.W,
-                (temperature - 290)**2 * self.W
+                (temperature - 290)**2 * model.W
         ]
 
         return [


### PR DESCRIPTION
Typo from the porting. Fixes the source of W to be the model.