### PR TITLE
DEV: Updates to ITWM BaseMCO class to utilise WorkflowEvaluator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
     - export PATH=${HOME}/edm/bin:${PATH}
     - edm install --version 3.5 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git --branch enh/refactor-factory-plugin
+    - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
     - export PATH=${HOME}/edm/bin:${PATH}
     - edm install --version 3.5 -y click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git --branch enh/refactor-factory-plugin
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install 

--- a/itwm_example/mco/subprocess_workflow_evaluator.py
+++ b/itwm_example/mco/subprocess_workflow_evaluator.py
@@ -1,0 +1,107 @@
+import logging
+import os
+import subprocess
+
+from traits.api import Unicode
+
+from force_bdss.app.workflow_evaluator import WorkflowEvaluator
+
+log = logging.getLogger(__name__)
+
+
+class SubprocessWorkflowEvaluator(WorkflowEvaluator):
+    """A subclass of WorkflowSolver that spawns a subprocess to
+     evaluate a single point."""
+
+    #: The path to the force_bdss executable
+    executable_path = Unicode()
+
+    def _call_subprocess(self, command, user_input):
+        """Calls a subprocess to perform a command with parsed
+        user_input"""
+
+        log.info("Spawning subprocess: {}".format(command))
+
+        # Setting ETS_TOOLKIT=null before executing bdss prevents it
+        # from trying to create GUI every call, giving reducing the
+        # overhead by a factor of 2.
+        env = {**os.environ, "ETS_TOOLKIT": "null"}
+
+        # Spawn the single point evaluation, which is the bdss itself
+        # with the option evaluate.
+        # We pass the specific parameter values via stdin, and read
+        # the result via stdout.
+        process = subprocess.Popen(
+            command,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
+
+        log.info("Sending values: {}".format(user_input))
+        stdout, stderr = process.communicate(
+            " ".join(user_input).encode("utf-8")
+        )
+
+        return stdout
+
+    def _subprocess_evaluate(self, parameter_values):
+        """Executes the workflow using the given parameter values
+        running on an external process via the subprocess library.
+        Values for each parameter in thw workflow to calculate a
+        single point
+        """
+
+        # This command calls a force_bdss executable on another process
+        # to evaluate the same workflow at a state determined by the
+        # parameter values. A BaseMCOCommunicator will be needed to be
+        # defined in the workflow to receive the data and send back values
+        # corresponding to each KPI via the command line.
+        command = [self.executable_path,
+                   "--logfile",
+                   "bdss.log",
+                   "--evaluate",
+                   self.workflow_filepath]
+
+        # Converts the parameter values to a string to send via
+        # subprocess
+        string_values = [str(v) for v in parameter_values]
+
+        # Call subprocess to perform executable with user input
+        stdout = self._call_subprocess(command, string_values)
+
+        # Decode stdout into KPI float values
+        kpi_values = [float(x) for x in stdout.decode("utf-8").split()]
+
+        return kpi_values
+
+    def evaluate(self, parameter_values):
+        """Public method to evaluate the workflow at a given set of
+        MCO parameter values
+
+        Parameters
+        ----------
+        parameter_values: list
+            List of values to assign to each BaseMCOParameter defined
+            in the workflow
+
+        Returns
+        -------
+        kpi_results: list
+            List of values corresponding to each MCO KPI in the
+            workflow
+        """
+
+        try:
+            return self._subprocess_evaluate(parameter_values)
+
+        except Exception:
+            message = (
+                'SubprocessWorkflowEvaluator failed '
+                'to run. This is likely due to an error in the '
+                'BaseMCOCommunicator assigned to {}.'.format(
+                    self.mco_model.factory.__class__)
+            )
+            log.exception(message)
+            raise RuntimeError(message)

--- a/itwm_example/mco/subprocess_workflow_evaluator.py
+++ b/itwm_example/mco/subprocess_workflow_evaluator.py
@@ -4,7 +4,7 @@ import subprocess
 
 from traits.api import Unicode
 
-from force_bdss.app.workflow_evaluator import WorkflowEvaluator
+from force_bdss.api import WorkflowEvaluator
 
 log = logging.getLogger(__name__)
 

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -25,7 +25,8 @@ class MockEval():
 class TestMCO(TestCase):
 
     def setUp(self):
-        self.factory = MCOFactory('pid')
+        self.plugin = {'id': 'pid', 'name': 'Plugin'}
+        self.factory = MCOFactory(self.plugin)
         self.mco = self.factory.create_optimizer()
         self.mco_model = self.factory.create_model()
 

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -1,9 +1,8 @@
 from unittest import mock, TestCase
 
 from force_bdss.api import (
-    KPISpecification, Workflow, DataValue
+    KPISpecification, Workflow, DataValue, WorkflowEvaluator
 )
-from force_bdss.app.workflow_evaluator import WorkflowEvaluator
 
 from itwm_example.mco.mco import (
     get_weight_combinations, WeightedEvaluator,

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -1,18 +1,15 @@
-import unittest
-from unittest import mock
+from unittest import mock, TestCase
 
 from force_bdss.api import (
-    KPISpecification, Workflow
+    KPISpecification, Workflow, DataValue
 )
-from force_bdss.tests.probe_classes.mco import ProbeMCOFactory
-from force_bdss.tests.probe_classes.probe_extension_plugin import (
-    ProbeExtensionPlugin
-    )
+from force_bdss.app.workflow_evaluator import WorkflowEvaluator
 
 from itwm_example.mco.mco import (
-    get_weight_combinations, MCO, InternalSinglePointEvaluator,
+    get_weight_combinations, WeightedEvaluator,
     get_scaling_factors
     )
+from itwm_example.mco.mco_factory import MCOFactory
 
 
 class MockEval():
@@ -26,39 +23,48 @@ class MockEval():
         return 0, result
 
 
-class TestMCO(unittest.TestCase):
-    def setUp(self):
-        self.plugin = ProbeExtensionPlugin()
-        self.factory = ProbeMCOFactory(self.plugin)
+class TestMCO(TestCase):
 
-        self.mco = MCO(self.factory)
+    def setUp(self):
+        self.factory = MCOFactory('pid')
+        self.mco = self.factory.create_optimizer()
+        self.mco_model = self.factory.create_model()
+
         self.kpis = [KPISpecification(), KPISpecification()]
         self.parameters = [1, 1, 1, 1]
 
-        self.mock_evaluator = mock.Mock(spec=InternalSinglePointEvaluator)
-
-    def test_internal_single_point_evaluator(self):
-        parameter_factory = self.factory.parameter_factories[0]
-        parameters = [
-            parameter_factory.create_model()
+        self.mco_model.kpis = self.kpis
+        self.mco_model.parameters = [
+            self.factory.parameter_factories[0].create_model()
             for _ in self.parameters
         ]
+        self.evaluator = WorkflowEvaluator(
+            workflow=Workflow()
+        )
+        self.evaluator.workflow.mco = self.mco_model
 
-        evaluator = InternalSinglePointEvaluator(
-            workflow=Workflow(),
+    def test_internal_weighted_evaluator(self):
+        parameters = self.mco_model.parameters
+
+        evaluator = WeightedEvaluator(
+            single_point_evaluator=self.evaluator,
+            weights=[0.5, 0.5],
             parameters=parameters
         )
+        mock_kpi_return = [
+            DataValue(value=2), DataValue(value=3)
+        ]
 
         with mock.patch('force_bdss.api.Workflow.execute',
-                        return_value=[]) as mock_exec:
-            evaluator.evaluate(self.parameters)
-            self.assertEqual(mock_exec.call_count, 1)
+                        return_value=mock_kpi_return) as mock_exec:
+            evaluator.optimize()
+            self.assertEqual(7, mock_exec.call_count)
 
     def test_scaling_factors(self):
 
         with mock.patch('itwm_example.mco.mco.WeightedEvaluator') as mock_eval:
             mock_eval.side_effect = MockEval
-            scaling_factors = get_scaling_factors(self.mock_evaluator,
+            scaling_factors = get_scaling_factors(self.evaluator,
                                                   self.kpis,
                                                   self.parameters)
 
@@ -70,7 +76,7 @@ class TestMCO(unittest.TestCase):
 
         with mock.patch('itwm_example.mco.mco.WeightedEvaluator') as mock_eval:
             mock_eval.side_effect = MockEval
-            scaling_factors = get_scaling_factors(self.mock_evaluator,
+            scaling_factors = get_scaling_factors(self.evaluator,
                                                   temp_kpis,
                                                   self.parameters)
 

--- a/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
+++ b/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
@@ -1,0 +1,64 @@
+import unittest
+
+from unittest import mock
+
+from force_bdss.api import BaseMCOFactory, Workflow
+
+from enthought_example.example_mco.example_mco_model import ExampleMCOModel
+from enthought_example.example_mco.example_mco import (
+    SubprocessWorkflowEvaluator
+)
+
+
+class TestSubprocessWorkflowEvaluator(unittest.TestCase):
+
+    def setUp(self):
+
+        self.evaluator = SubprocessWorkflowEvaluator(
+            workflow=Workflow(),
+            workflow_filepath="test_probe.json"
+        )
+        self.mock_process = mock.Mock()
+        self.mock_process.communicate = mock.Mock(
+            return_value=(b"2", b"1 0")
+        )
+
+    def test___call_subprocess(self):
+
+        # Test simple bash command
+        stdout = self.evaluator._call_subprocess(
+            'uniq', ['Hello', 'World']
+        )
+        self.assertEqual(
+            'Hello World', stdout.decode("utf-8").strip()
+        )
+
+    def test__subprocess_solve(self):
+        factory = mock.Mock(spec=BaseMCOFactory)
+        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+
+        with mock.patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value = self.mock_process
+            kpi_results = self.evaluator._subprocess_evaluate([1.0])
+
+        self.assertEqual(1, len(kpi_results))
+
+    def test_solve_error_mco_communicator(self):
+
+        def mock_subprocess_evaluate(self, *args):
+            raise Exception
+
+        factory = mock.Mock(spec=BaseMCOFactory)
+        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+
+        with mock.patch('enthought_example.example_mco.example_mco'
+                        '.SubprocessWorkflowEvaluator._subprocess_evaluate',
+                        side_effect=mock_subprocess_evaluate):
+            with self.assertRaisesRegex(
+                    RuntimeError,
+                    'SubprocessWorkflowEvaluator failed '
+                    'to run. This is likely due to an error in the '
+                    'BaseMCOCommunicator assigned to '
+                    "<class 'force_bdss.mco.base_mco_factory."
+                    "BaseMCOFactory'>."):
+                self.evaluator.evaluate([1.0])

--- a/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
+++ b/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
@@ -27,7 +27,7 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
 
         # Test simple bash command
         stdout = self.evaluator._call_subprocess(
-            'uniq', ['Hello', 'World']
+            ['uniq'], ['Hello', 'World']
         )
         self.assertEqual(
             'Hello World', stdout.decode("utf-8").strip()

--- a/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
+++ b/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 from force_bdss.api import BaseMCOFactory, Workflow
 
-from enthought_example.example_mco.example_mco_model import ExampleMCOModel
-from enthought_example.example_mco.example_mco import (
+from itwm_example.mco.mco_model import MCOModel
+from itwm_example.mco.subprocess_workflow_evaluator import (
     SubprocessWorkflowEvaluator
 )
 
@@ -35,7 +35,7 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
 
     def test__subprocess_solve(self):
         factory = mock.Mock(spec=BaseMCOFactory)
-        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+        self.evaluator.workflow.mco = MCOModel(factory)
 
         with mock.patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value = self.mock_process
@@ -49,9 +49,9 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
             raise Exception
 
         factory = mock.Mock(spec=BaseMCOFactory)
-        self.evaluator.workflow.mco = ExampleMCOModel(factory)
+        self.evaluator.workflow.mco = MCOModel(factory)
 
-        with mock.patch('enthought_example.example_mco.example_mco'
+        with mock.patch('itwm_example.mco.subprocess_workflow_evaluator'
                         '.SubprocessWorkflowEvaluator._subprocess_evaluate',
                         side_effect=mock_subprocess_evaluate):
             with self.assertRaisesRegex(


### PR DESCRIPTION
This PR implements updates required by the refactoring of `force_bdss` in force-h2020/force-bdss/pull/232. It is very similar in content to force-h2020/force-bdss-plugin-enthought-example/pull/34

It simplifies the `MCO` class by using the in built functionalities of the new `WorkflowEvaluator` class, removing any `ISinglePointEvaluator` subclasses.

A new subclass `SubprocessWorkflowEvaluator` is also included to spawn a subprocess that calls another `force_bdss` executable to perform the same evaluation (current functionality implemented in both `force-bdss-plugin-enthought-example` and `force-bdss-plugin-itwm-example` `BaseMCO` subclasses).

**Note:** this branch is pinned to `force-bdss/enh/refactor-factory-plugin` and should not be merged before force-h2020/force-bdss/pull/232 is closed

### Change Log
- `ISinglePointEvaluator`, `InternalSinglePointEvaluator` and `SubprocessSinglePointEvaluator` classes removed
- New class `SubprocessWorkflowEvaluator`, which is a subclass of `WorkflowEvaluator`
- `BaseMCO` subclasses `run` methods now expect a `evaluator` argument, rather than `model`. These methods have also been amended to call `evaluator.evaluate(<list of parameters>)` to calculate the KPIs at each data point.
- All `factory.plugin.id` references updated to `factory.plugin_id`
- All `factory.plugin.application` references removed

## Known Issues
- The codecov is low (linked to #41), and should be improved for the `BaseMCO` class at least before merging