### PR TITLE
TST: Capture log.exception in Unit tests

### DIFF
--- a/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
+++ b/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
@@ -1,5 +1,5 @@
+import testfixtures
 import unittest
-
 from unittest import mock
 
 from force_bdss.api import BaseMCOFactory, Workflow
@@ -54,11 +54,12 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
         with mock.patch('itwm_example.mco.subprocess_workflow_evaluator'
                         '.SubprocessWorkflowEvaluator._subprocess_evaluate',
                         side_effect=mock_subprocess_evaluate):
-            with self.assertRaisesRegex(
-                    RuntimeError,
-                    'SubprocessWorkflowEvaluator failed '
-                    'to run. This is likely due to an error in the '
-                    'BaseMCOCommunicator assigned to '
-                    "<class 'force_bdss.mco.base_mco_factory."
-                    "BaseMCOFactory'>."):
-                self.evaluator.evaluate([1.0])
+            with testfixtures.LogCapture():
+                with self.assertRaisesRegex(
+                        RuntimeError,
+                        'SubprocessWorkflowEvaluator failed '
+                        'to run. This is likely due to an error in the '
+                        'BaseMCOCommunicator assigned to '
+                        "<class 'force_bdss.mco.base_mco_factory."
+                        "BaseMCOFactory'>."):
+                    self.evaluator.evaluate([1.0])

--- a/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
+++ b/itwm_example/mco/tests/test_subprocess_workflow_evaluator.py
@@ -54,12 +54,14 @@ class TestSubprocessWorkflowEvaluator(unittest.TestCase):
         with mock.patch('itwm_example.mco.subprocess_workflow_evaluator'
                         '.SubprocessWorkflowEvaluator._subprocess_evaluate',
                         side_effect=mock_subprocess_evaluate):
-            with testfixtures.LogCapture():
-                with self.assertRaisesRegex(
-                        RuntimeError,
-                        'SubprocessWorkflowEvaluator failed '
-                        'to run. This is likely due to an error in the '
-                        'BaseMCOCommunicator assigned to '
-                        "<class 'force_bdss.mco.base_mco_factory."
-                        "BaseMCOFactory'>."):
+            with testfixtures.LogCapture() as log:
+                with self.assertRaises(RuntimeError):
                     self.evaluator.evaluate([1.0])
+                log.check(
+                    ('itwm_example.mco.subprocess_workflow_evaluator',
+                     'ERROR',
+                     'SubprocessWorkflowEvaluator failed to run. '
+                     'This is likely due to an error '
+                     'in the BaseMCOCommunicator assigned to <class '
+                     "'force_bdss.mco.base_mco_factory.BaseMCOFactory'>.")
+                )


### PR DESCRIPTION
Imported `testfixtures` library in `TestSubprocessWorkflowEvaluator` to capture logged exception that was being reported in unit testing of `test_solve_mco_communicator`.

This change has no effect on the outcome of the unit tests; it only suppresses a redundant (and potentially confusing) exception message being shown in the report.