### PR TITLE
MCO refactoring to add new optimizers

### DIFF
--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -8,8 +8,10 @@ ADDITIONAL_CORE_DEPS = [
     "scipy>=1.2.1"
 ]
 
+_nevergrad_stable_commit = "ba2c0217a043178adf9fe9f4bd52bbbfce97bfaa"
 PIP_DEPS = [
-    "git+https://github.com/facebookresearch/nevergrad@master#egg=nevergrad"
+    "git+https://github.com/facebookresearch/nevergrad.git@" +
+    _nevergrad_stable_commit
 ]
 
 

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -81,7 +81,7 @@ def docs(python_version):
 
 
 def get_env_name(python_version):
-    return "force-nevergrad{}".format(remove_dot(python_version))
+    return "force-py{}".format(remove_dot(python_version))
 
 
 def remove_dot(python_version):

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -81,7 +81,7 @@ def docs(python_version):
 
 
 def get_env_name(python_version):
-    return "force-py{}".format(remove_dot(python_version))
+    return "force-nevergrad{}".format(remove_dot(python_version))
 
 
 def remove_dot(python_version):

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -12,6 +12,7 @@ PIP_DEPS = [
     "git+https://github.com/facebookresearch/nevergrad@master#egg=nevergrad"
 ]
 
+
 @click.group()
 def cli():
     pass

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -8,6 +8,9 @@ ADDITIONAL_CORE_DEPS = [
     "scipy>=1.2.1"
 ]
 
+PIP_DEPS = [
+    "git+https://github.com/facebookresearch/nevergrad@master#egg=nevergrad"
+]
 
 @click.group()
 def cli():
@@ -33,6 +36,11 @@ def install(python_version):
     check_call([
         "edm", "run", "-e", env_name, "--",
         "pip", "install", "-e", "."])
+
+    if len(PIP_DEPS):
+        check_call([
+            "edm", "run", "-e", env_name, "--",
+            "pip", "install"] + PIP_DEPS)
 
 
 @cli.command(help="Run the tests")
@@ -72,7 +80,7 @@ def docs(python_version):
 
 
 def get_env_name(python_version):
-    return "force-py{}".format(remove_dot(python_version))
+    return "force-nevergrad{}".format(remove_dot(python_version))
 
 
 def remove_dot(python_version):

--- a/itwm_example/mco/mco.py
+++ b/itwm_example/mco/mco.py
@@ -1,18 +1,14 @@
 import logging
 import sys
 
-import numpy as np
-
-from traits.api import Type
+from traits.api import Enum
 
 from force_bdss.api import BaseMCO, DataValue
 
 from .subprocess_workflow_evaluator import SubprocessWorkflowEvaluator
-from .scaling_tools.kpi_scaling import sen_scaling_method
-from .optimizers.optimizers import IOptimizer, WeightedOptimizer, NevergradOptimizer
-from .space_sampling.space_samplers import (
-    UniformSpaceSampler,
-    DirichletSpaceSampler,
+from .optimizers.optimizers import (
+    WeightedOptimizer,
+    NevergradOptimizer,
 )
 
 log = logging.getLogger(__name__)
@@ -20,76 +16,14 @@ log = logging.getLogger(__name__)
 
 class MCO(BaseMCO):
 
-    optimizer = Type(IOptimizer)
-
-    scaling_method = staticmethod(sen_scaling_method)
+    optimizer = Enum(WeightedOptimizer, NevergradOptimizer)
 
     def _optimizer_default(self):
         return WeightedOptimizer
 
-    def get_scaling_factors(self, optimizer, kpis, scaling_method=None):
-        """Calculates scaling factors for KPIs, defined in MCO.
-        Scaling factors are calculated (as required) by the provided scaling
-        method. In general, this provides normalization values for the possible
-        range of each KPI..
-        Performs scaling for all KPIs that have `auto_scale == True`.
-        Otherwise, keeps the default scale factor.
-
-        Parameters
-        ----------
-        optimizer: IOptimizer instance
-            Instance that provides optimization functionality
-        kpis: List[KPISpecification]
-            List of KPI objects to scale
-        scaling_method: callable
-            A method to scale KPI weights. Default set to the Sen's
-            "Multi-Objective Programming Method"
-        """
-        if scaling_method is None:
-            scaling_method = self.scaling_method
-
-        #: Get default scaling weights for each KPI variable
-        default_scaling_factors = np.array([kpi.scale_factor for kpi in kpis])
-
-        #: Apply a wrapper for the evaluator weights assignment and
-        #: call of the .optimize method.
-        #: Then, calculate scaling factors defined by the `scaling_method`
-        scaling_factors = scaling_method(len(kpis), optimizer.optimize)
-
-        #: Apply the scaling factors where necessary
-        auto_scales = [kpi.auto_scale for kpi in kpis]
-        default_scaling_factors[auto_scales] = scaling_factors[auto_scales]
-
-        log.info(
-            "Using KPI scaling factors: {}".format(default_scaling_factors)
-        )
-
-        return default_scaling_factors.tolist()
-
-    @staticmethod
-    def _space_search_distribution(model, **kwargs):
-        """ Generates space search distribution object, based on
-        the user settings of the `space_search_strategy` trait."""
-
-        if model.space_search_mode == "Uniform":
-            distribution = UniformSpaceSampler
-        elif model.space_search_mode == "Dirichlet":
-            distribution = DirichletSpaceSampler
-        else:
-            raise NotImplementedError
-        return distribution(len(model.kpis), model.num_points, **kwargs)
-
-    def weights_samples(self, model, **kwargs):
-        """ Generates necessary number of search space sample points
-        from the internal search strategy."""
-        return self._space_search_distribution(
-            model, **kwargs
-        ).generate_space_sample()
-
     def run(self, evaluator):
 
         model = evaluator.mco_model
-        kpis = model.kpis
 
         if model.evaluation_mode == "Subprocess":
             # Here we create an instance of our WorkflowEvaluator subclass
@@ -106,18 +40,11 @@ class MCO(BaseMCO):
 
         optimizer = self.optimizer(evaluator, model)
 
-        #: Get scaling factors and non-zero weight combinations for each KPI
-        scaling_factors = self.get_scaling_factors(optimizer, kpis)
-        for weights in self.weights_samples(model):
-
-            log.info("Doing MCO run with weights: {}".format(weights))
-
-            scaled_weights = [
-                weight * scale
-                for weight, scale in zip(weights, scaling_factors)
-            ]
-
-            optimal_point, optimal_kpis = optimizer.optimize(scaled_weights)
+        for (
+            optimal_point,
+            optimal_kpis,
+            scaled_weights,
+        ) in optimizer.optimize():
 
             # When there is new data, this operation informs the system that
             # new data has been received. It must be a dictionary as given.
@@ -125,13 +52,4 @@ class MCO(BaseMCO):
                 [DataValue(value=v) for v in optimal_point],
                 [DataValue(value=v) for v in optimal_kpis],
                 scaled_weights,
-            )
-
-        self.optimizer = NevergradOptimizer
-        optimizer = self.optimizer(evaluator, model)
-        for optimal_point, optimal_kpis in optimizer.optimize():
-            self.notify_new_point(
-                [DataValue(value=v) for v in optimal_point],
-                [DataValue(value=v) for v in optimal_kpis],
-                [1, 1, 1],
             )

--- a/itwm_example/mco/mco.py
+++ b/itwm_example/mco/mco.py
@@ -9,7 +9,7 @@ from force_bdss.api import BaseMCO, DataValue
 
 from .subprocess_workflow_evaluator import SubprocessWorkflowEvaluator
 from .scaling_tools.kpi_scaling import sen_scaling_method
-from .optimizers.optimizers import IOptimizer, WeightedOptimizer
+from .optimizers.optimizers import IOptimizer, WeightedOptimizer, NevergradOptimizer
 from .space_sampling.space_samplers import (
     UniformSpaceSampler,
     DirichletSpaceSampler,
@@ -108,7 +108,6 @@ class MCO(BaseMCO):
 
         #: Get scaling factors and non-zero weight combinations for each KPI
         scaling_factors = self.get_scaling_factors(optimizer, kpis)
-
         for weights in self.weights_samples(model):
 
             log.info("Doing MCO run with weights: {}".format(weights))
@@ -126,4 +125,13 @@ class MCO(BaseMCO):
                 [DataValue(value=v) for v in optimal_point],
                 [DataValue(value=v) for v in optimal_kpis],
                 scaled_weights,
+            )
+
+        self.optimizer = NevergradOptimizer
+        optimizer = self.optimizer(evaluator, model)
+        for optimal_point, optimal_kpis in optimizer.optimize():
+            self.notify_new_point(
+                [DataValue(value=v) for v in optimal_point],
+                [DataValue(value=v) for v in optimal_kpis],
+                [1, 1, 1],
             )

--- a/itwm_example/mco/mco.py
+++ b/itwm_example/mco/mco.py
@@ -104,7 +104,7 @@ class MCO(BaseMCO):
                 executable_path=sys.argv[0],
             )
 
-        optimizer = self.optimizer(evaluator, model.parameters)
+        optimizer = self.optimizer(evaluator, model)
 
         #: Get scaling factors and non-zero weight combinations for each KPI
         scaling_factors = self.get_scaling_factors(optimizer, kpis)

--- a/itwm_example/mco/mco.py
+++ b/itwm_example/mco/mco.py
@@ -18,9 +18,9 @@ class MCO(BaseMCO):
         if model.evaluation_mode == "Subprocess":
             # Here we create an instance of our WorkflowEvaluator subclass
             # that allows for evaluation of a state in the workflow via calling
-            # force_bdss on a new subprocess running in 'evaluate' mode.
+            # `force_bdss` on a new subprocess running in 'evaluate' mode.
             # Note: a BaseMCOCommunicator must be present to pass in parameter
-            # values and returning the KPI for a force_bdss run in 'evaluate'
+            # values and returning the KPI for a `force_bdss` run in 'evaluate'
             # mode
             evaluator = SubprocessWorkflowEvaluator(
                 workflow=evaluator.workflow,

--- a/itwm_example/mco/mco.py
+++ b/itwm_example/mco/mco.py
@@ -1,25 +1,15 @@
 import logging
 import sys
 
-from traits.api import Enum
-
 from force_bdss.api import BaseMCO, DataValue
 
 from .subprocess_workflow_evaluator import SubprocessWorkflowEvaluator
-from .optimizers.optimizers import (
-    WeightedOptimizer,
-    NevergradOptimizer,
-)
+
 
 log = logging.getLogger(__name__)
 
 
 class MCO(BaseMCO):
-
-    optimizer = Enum(WeightedOptimizer, NevergradOptimizer)
-
-    def _optimizer_default(self):
-        return WeightedOptimizer
 
     def run(self, evaluator):
 
@@ -37,8 +27,8 @@ class MCO(BaseMCO):
                 workflow_filepath=evaluator.workflow_filepath,
                 executable_path=sys.argv[0],
             )
-
-        optimizer = self.optimizer(evaluator, model)
+        optimizer = model.optimizer
+        optimizer.single_point_evaluator = evaluator
 
         for (
             optimal_point,

--- a/itwm_example/mco/mco_model.py
+++ b/itwm_example/mco/mco_model.py
@@ -1,18 +1,67 @@
-from traits.api import Enum
-from traitsui.api import View, Item
-from force_bdss.api import BaseMCOModel, PositiveInt
+from traits.api import Enum, Instance, on_trait_change, Dict
+from traitsui.api import View, Item, InstanceEditor
+from force_bdss.api import BaseMCOModel
+
+from .optimizers.optimizers import (
+    IOptimizer,
+    WeightedOptimizer,
+    NevergradOptimizer,
+)
 
 
 class MCOModel(BaseMCOModel):
-    num_points = PositiveInt(7)
 
     evaluation_mode = Enum("Internal", "Subprocess")
 
-    space_search_mode = Enum("Uniform", "Dirichlet")
+    optimizer_mode = Enum("Weighted", "NeverGrad")
+
+    optimizer = Instance(IOptimizer, transient=True)
+
+    optimizer_data = Dict()
+
+    def __init__(self, *args, **kwargs):
+        optimizer_mode = kwargs.pop("optimizer_mode", None)
+        super().__init__(*args, **kwargs)
+        if optimizer_mode is not None:
+            self.optimizer_mode = optimizer_mode
 
     def default_traits_view(self):
         return View(
-            Item("num_points"),
             Item("evaluation_mode"),
-            Item("space_search_mode"),
+            Item("optimizer_mode"),
+            Item("optimizer", style="custom", editor=InstanceEditor()),
         )
+
+    def _optimizer_from_mode(self):
+        if self.optimizer_mode == "Weighted":
+            klass = WeightedOptimizer
+        elif self.optimizer_mode == "NeverGrad":
+            klass = NevergradOptimizer
+        return klass
+
+    def _optimizer_default(self):
+        klass = self._optimizer_from_mode()
+        return klass(
+            kpis=self.kpis, parameters=self.parameters, **self.optimizer_data
+        )
+
+    @on_trait_change("optimizer_mode")
+    def update_optimizer(self):
+        klass = self._optimizer_from_mode()
+        self.optimizer = klass(
+            kpis=self.kpis, parameters=self.parameters, **self.optimizer_data
+        )
+
+    @on_trait_change("kpis")
+    def update_kpis(self):
+        self.optimizer.kpis = self.kpis
+
+    @on_trait_change("parameters")
+    def update_parameters(self):
+        self.optimizer.parameters = self.parameters
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        state["optimizer_data"] = self.optimizer.__getstate__()
+        # state.pop("optimizer")
+        return state

--- a/itwm_example/mco/mco_model.py
+++ b/itwm_example/mco/mco_model.py
@@ -21,9 +21,8 @@ class MCOModel(BaseMCOModel):
 
     def __init__(self, *args, **kwargs):
         # We pop out the optimizer data to avoid inconsistent data
-        # assignment to the default optimizer instace, which is created
+        # assignment to the default optimizer instance, which is created
         # during super().__init__
-        optimizer_mode = kwargs.pop("optimizer_mode", None)
         optimizer_data = kwargs.pop("optimizer_data", None)
 
         super().__init__(*args, **kwargs)
@@ -33,8 +32,7 @@ class MCOModel(BaseMCOModel):
         # other attributes have been assigned.
         if optimizer_data is not None:
             self.optimizer_data = optimizer_data
-        if optimizer_mode is not None:
-            self.optimizer_mode = optimizer_mode
+        self.optimizer = self._optimizer_default()
 
     def default_traits_view(self):
         return View(
@@ -44,6 +42,7 @@ class MCOModel(BaseMCOModel):
         )
 
     def _optimizer_from_mode(self):
+        klass = None
         if self.optimizer_mode == "Weighted":
             klass = WeightedOptimizer
         elif self.optimizer_mode == "NeverGrad":
@@ -61,7 +60,7 @@ class MCOModel(BaseMCOModel):
         klass = self._optimizer_from_mode()
         # In order to prevent collisions in "algorithms" Enum object, we pop
         # it out and therefore always have the default value of "algorithms"
-        # on switch
+        # and "name" on switch
         self.optimizer_data.pop("algorithms", None)
         self.optimizer_data.pop("name", None)
         self.optimizer = klass(

--- a/itwm_example/mco/mco_model.py
+++ b/itwm_example/mco/mco_model.py
@@ -20,12 +20,19 @@ class MCOModel(BaseMCOModel):
     optimizer_data = Dict()
 
     def __init__(self, *args, **kwargs):
+        # We pop out the optimizer data to avoid inconsistent data
+        # assignment to the default optimizer instace, which is created
+        # during super().__init__
         optimizer_mode = kwargs.pop("optimizer_mode", None)
+        optimizer_data = kwargs.pop("optimizer_data", None)
+
         super().__init__(*args, **kwargs)
-        # Optimizer is created once the "optimizer_mode" is specified.
+        # Optimizer is created with proper "optimizer_mode" (not default).
         # It should only be created _after_ the parameters and KPIs
         # have been specified. We instantiate the optimizer after all
         # other attributes have been assigned.
+        if optimizer_data is not None:
+            self.optimizer_data = optimizer_data
         if optimizer_mode is not None:
             self.optimizer_mode = optimizer_mode
 
@@ -56,6 +63,7 @@ class MCOModel(BaseMCOModel):
         # it out and therefore always have the default value of "algorithms"
         # on switch
         self.optimizer_data.pop("algorithms", None)
+        self.optimizer_data.pop("name", None)
         self.optimizer = klass(
             kpis=self.kpis, parameters=self.parameters, **self.optimizer_data
         )

--- a/itwm_example/mco/mco_model.py
+++ b/itwm_example/mco/mco_model.py
@@ -22,6 +22,10 @@ class MCOModel(BaseMCOModel):
     def __init__(self, *args, **kwargs):
         optimizer_mode = kwargs.pop("optimizer_mode", None)
         super().__init__(*args, **kwargs)
+        # Optimizer is created once the "optimizer_mode" is specified.
+        # It should only be created _after_ the parameters and KPIs
+        # have been specified. We instantiate the optimizer after all
+        # other attributes have been assigned.
         if optimizer_mode is not None:
             self.optimizer_mode = optimizer_mode
 

--- a/itwm_example/mco/mco_model.py
+++ b/itwm_example/mco/mco_model.py
@@ -48,6 +48,10 @@ class MCOModel(BaseMCOModel):
     @on_trait_change("optimizer_mode")
     def update_optimizer(self):
         klass = self._optimizer_from_mode()
+        # In order to prevent collisions in "algorithms" Enum object, we pop
+        # it out and therefore always have the default value of "algorithms"
+        # on switch
+        self.optimizer_data.pop("algorithms", None)
         self.optimizer = klass(
             kpis=self.kpis, parameters=self.parameters, **self.optimizer_data
         )
@@ -63,5 +67,4 @@ class MCOModel(BaseMCOModel):
     def __getstate__(self):
         state = super().__getstate__()
         state["optimizer_data"] = self.optimizer.__getstate__()
-        # state.pop("optimizer")
         return state

--- a/itwm_example/mco/optimizers/optimizers.py
+++ b/itwm_example/mco/optimizers/optimizers.py
@@ -6,12 +6,22 @@ from scipy import optimize as scipy_optimize
 import nevergrad as ng
 from nevergrad.functions import MultiobjectiveFunction
 
-from traits.api import Interface, HasStrictTraits, provides, List, Instance
+from traits.api import (
+    Interface,
+    HasTraits,
+    HasStrictTraits,
+    provides,
+    Instance,
+)
 
-from force_bdss.api import BaseMCOParameter
 from force_bdss.mco.i_evaluator import IEvaluator
 
 from itwm_example.mco.mco_model import MCOModel
+from itwm_example.mco.scaling_tools.kpi_scaling import sen_scaling_method
+from itwm_example.mco.space_sampling.space_samplers import (
+    UniformSpaceSampler,
+    DirichletSpaceSampler,
+)
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +35,7 @@ class IOptimizer(Interface):
 
 
 @provides(IOptimizer)
-class WeightedOptimizer(HasStrictTraits):
+class WeightedOptimizer(HasTraits):
     """Performs a scipy optimise with SLSQP method given a set of weights
     for the individual KPIs.
     """
@@ -33,6 +43,8 @@ class WeightedOptimizer(HasStrictTraits):
     single_point_evaluator = Instance(IEvaluator)
 
     model = Instance(MCOModel)
+
+    scaling_method = staticmethod(sen_scaling_method)
 
     def __init__(self, single_point_evaluator, model):
         super().__init__(
@@ -47,8 +59,80 @@ class WeightedOptimizer(HasStrictTraits):
 
         return score
 
-    def optimize(self, weights):
-        return self._weighted_optimize(weights)
+    def get_scaling_factors(self, scaling_method=None):
+        """ Calculates scaling factors for KPIs, defined in MCO.
+        Scaling factors are calculated (as required) by the provided scaling
+        method. In general, this provides normalization values for the possible
+        range of each KPI.
+        Performs scaling for all KPIs that have `auto_scale == True`.
+        Otherwise, keeps the default scale factor.
+
+        Parameters
+        ----------
+        scaling_method: callable
+            A method to scale KPI weights. Default set to the Sen's
+            "Multi-Objective Programming Method"
+        """
+        if scaling_method is None:
+            scaling_method = self.scaling_method
+
+        kpis = self.model.kpis
+
+        #: Get default scaling weights for each KPI variable
+        default_scaling_factors = np.array([kpi.scale_factor for kpi in kpis])
+
+        #: Apply a wrapper for the evaluator weights assignment and
+        #: call of the .optimize method.
+        #: Then, calculate scaling factors defined by the `scaling_method`
+        scaling_factors = scaling_method(len(kpis), self._weighted_optimize)
+
+        #: Apply the scaling factors where necessary
+        auto_scales = [kpi.auto_scale for kpi in kpis]
+        default_scaling_factors[auto_scales] = scaling_factors[auto_scales]
+
+        log.info(
+            "Using KPI scaling factors: {}".format(default_scaling_factors)
+        )
+
+        return default_scaling_factors.tolist()
+
+    def _space_search_distribution(self, **kwargs):
+        """ Generates space search distribution object, based on
+        the user settings of the `space_search_strategy` trait."""
+
+        if self.model.space_search_mode == "Uniform":
+            distribution = UniformSpaceSampler
+        elif self.model.space_search_mode == "Dirichlet":
+            distribution = DirichletSpaceSampler
+        else:
+            raise NotImplementedError
+        return distribution(
+            len(self.model.kpis), self.model.num_points, **kwargs
+        )
+
+    def weights_samples(self, **kwargs):
+        """ Generates necessary number of search space sample points
+        from the internal search strategy."""
+        return self._space_search_distribution(
+            **kwargs
+        ).generate_space_sample()
+
+    def optimize(self):
+        #: Get scaling factors and non-zero weight combinations for each KPI
+        scaling_factors = self.get_scaling_factors()
+        for weights in self.weights_samples():
+
+            log.info("Doing MCO run with weights: {}".format(weights))
+
+            scaled_weights = [
+                weight * scale
+                for weight, scale in zip(weights, scaling_factors)
+            ]
+
+            optimal_point, optimal_kpis = self._weighted_optimize(
+                scaled_weights
+            )
+            yield optimal_point, optimal_kpis, scaled_weights
 
     def _weighted_optimize(self, weights):
         initial_point = [p.initial_value for p in self.model.parameters]

--- a/itwm_example/mco/optimizers/optimizers.py
+++ b/itwm_example/mco/optimizers/optimizers.py
@@ -29,6 +29,9 @@ class IOptimizer(Interface):
     def optimize(self):
         """ Perform an optimization procedure"""
 
+    def __getstate__(self):
+        """ Serialization of the optimizer state"""
+
 
 @provides(IOptimizer)
 class WeightedOptimizer(HasTraits):

--- a/itwm_example/mco/optimizers/optimizers.py
+++ b/itwm_example/mco/optimizers/optimizers.py
@@ -286,6 +286,7 @@ class NevergradOptimizer(HasTraits):
             multiobjective_function=self._score, upper_bounds=upper_bounds
         )
         instrumentation = self._create_instrumentation()
+        instrumentation.random_state.seed(12)
         ng_optimizer = ng.optimizers.registry[self.algorithms](
             instrumentation=instrumentation, budget=self.budget
         )

--- a/itwm_example/mco/optimizers/optimizers.py
+++ b/itwm_example/mco/optimizers/optimizers.py
@@ -41,12 +41,12 @@ class WeightedOptimizer(HasStrictTraits):
 
     single_point_evaluator = Instance(IEvaluator)
 
-    parameters = List(BaseMCOParameter)
+    model = Instance(MCOModel)
 
-    def __init__(self, single_point_evaluator, parameters):
+    def __init__(self, single_point_evaluator, model):
         super().__init__(
             single_point_evaluator=single_point_evaluator,
-            parameters=parameters,
+            model=model,
         )
 
     def _score(self, point, weights):
@@ -58,8 +58,8 @@ class WeightedOptimizer(HasStrictTraits):
         return score
 
     def optimize(self, weights):
-        initial_point = [p.initial_value for p in self.parameters]
-        constraints = [(p.lower_bound, p.upper_bound) for p in self.parameters]
+        initial_point = [p.initial_value for p in self.model.parameters]
+        constraints = [(p.lower_bound, p.upper_bound) for p in self.model.parameters]
 
         weighted_score_func = partial(self._score, weights=weights)
 
@@ -82,8 +82,6 @@ class WeightedOptimizer(HasStrictTraits):
 @provides(IOptimizer)
 class NevergradOptimizer(HasStrictTraits):
     single_point_evaluator = Instance(IEvaluator)
-
-    parameters = List(BaseMCOParameter)
 
     model = Instance(MCOModel)
 

--- a/itwm_example/mco/optimizers/optimizers.py
+++ b/itwm_example/mco/optimizers/optimizers.py
@@ -3,11 +3,15 @@ from functools import partial
 
 import numpy as np
 from scipy import optimize as scipy_optimize
+import nevergrad as ng
+from nevergrad.functions import MultiobjectiveFunction
 
 from traits.api import Interface, HasStrictTraits, provides, List, Instance
 
 from force_bdss.api import BaseMCOParameter
 from force_bdss.mco.i_evaluator import IEvaluator
+
+from itwm_example.mco.mco_model import MCOModel
 
 log = logging.getLogger(__name__)
 
@@ -73,3 +77,41 @@ class WeightedOptimizer(HasStrictTraits):
         )
 
         return optimal_point, optimal_kpis
+
+
+@provides(IOptimizer)
+class NevergradOptimizer(HasStrictTraits):
+    single_point_evaluator = Instance(IEvaluator)
+
+    parameters = List(BaseMCOParameter)
+
+    model = Instance(MCOModel)
+
+    def __init__(self, single_point_evaluator, model):
+        super().__init__(
+            single_point_evaluator=single_point_evaluator, model=model
+        )
+
+    def _score(self, point):
+        return self.single_point_evaluator.evaluate(point)
+
+    def optimize(self):
+        instrumentation = [
+            ng.var.Scalar().bounded(p.lower_bound, p.upper_bound)
+            for p in self.model.parameters
+        ]
+        instrumentation = ng.Instrumentation(*instrumentation)
+        f = MultiobjectiveFunction(
+            multiobjective_function=self._score,
+            upper_bounds=[100] * len(self.model.kpis),  # [0.4, 50, 5000]
+        )
+        budget = 200
+        ng_optimizer = ng.optimizers.registry["TwoPointsDE"](
+            instrumentation=instrumentation, budget=budget
+        )
+        for _ in range(ng_optimizer.budget):
+            x = ng_optimizer.ask()
+            value = f.multiobjective_function(x.args)
+            volume = f.compute_aggregate_loss(value, *x.args, **x.kwargs)
+            ng_optimizer.tell(x, volume)
+            yield x.args, value

--- a/itwm_example/mco/optimizers/optimizers.py
+++ b/itwm_example/mco/optimizers/optimizers.py
@@ -55,12 +55,6 @@ class WeightedOptimizer(HasTraits):
     #: Space search distribution for weight points sampling
     space_search_mode = Enum("Uniform", "Dirichlet")
 
-    def __init__(self, *args, **kwargs):
-        _algorithm = kwargs.pop("algorithms", None)
-        if _algorithm and _algorithm not in ["SLSQP", "TNC"]:
-            kwargs["algorithms"] = self.algorithms
-        super().__init__(*args, **kwargs)
-
     def default_traits_view(self):
         return View(
             Group(
@@ -195,12 +189,6 @@ class NevergradOptimizer(HasTraits):
 
     #: Optimization budget defines the allowed number of objective calls
     budget = PositiveInt(100)
-
-    def __init__(self, *args, **kwargs):
-        _algorithm = kwargs.pop("algorithms", None)
-        if _algorithm and _algorithm not in ng.optimizers.registry.keys():
-            kwargs["algorithms"] = self.algorithms
-        super().__init__(*args, **kwargs)
 
     def _algorithms_default(self):
         return "TwoPointsDE"

--- a/itwm_example/mco/optimizers/tests/test_optimizers.py
+++ b/itwm_example/mco/optimizers/tests/test_optimizers.py
@@ -1,0 +1,57 @@
+from unittest import TestCase
+
+from force_bdss.api import KPISpecification
+
+from itwm_example.mco.mco_factory import MCOFactory
+from itwm_example.mco.optimizers.optimizers import WeightedOptimizer
+from itwm_example.mco.space_sampling.space_samplers import (
+    UniformSpaceSampler,
+    DirichletSpaceSampler,
+)
+from itwm_example.mco.tests.mock_classes import MockOptimizer
+
+
+class TestWeightedOptimizer(TestCase):
+    def setUp(self):
+        self.plugin = {"id": "pid", "name": "Plugin"}
+        self.factory = MCOFactory(self.plugin)
+        self.mco_model = self.factory.create_model()
+
+        self.kpis = [KPISpecification(), KPISpecification()]
+        self.parameters = [1, 1, 1, 1]
+
+        self.mco_model.kpis = self.kpis
+        self.mco_model.parameters = [
+            self.factory.parameter_factories[0].create_model()
+            for _ in self.parameters
+        ]
+
+        self.optimizer = WeightedOptimizer(None, self.mco_model)
+
+    def test__space_search_distribution(self):
+        for strategy, klass in (
+            ("Uniform", UniformSpaceSampler),
+            ("Dirichlet", DirichletSpaceSampler),
+            ("Uniform", UniformSpaceSampler),
+        ):
+            self.mco_model.space_search_mode = strategy
+            distribution = self.optimizer._space_search_distribution()
+            self.assertIsInstance(distribution, klass)
+            self.assertEqual(len(self.kpis), distribution.dimension)
+            self.assertEqual(7, distribution.resolution)
+
+    def test_auto_scale(self):
+        temp_kpis = [KPISpecification(), KPISpecification(auto_scale=False)]
+        self.mco_model.kpis = temp_kpis
+
+        mock_optimizer = MockOptimizer(None, None)
+        self.optimizer._weighted_optimize = mock_optimizer.optimize
+
+        scaling_factors = self.optimizer.get_scaling_factors()
+        self.assertEqual([0.1, 1.0], scaling_factors)
+
+    def test_scaling_factors(self):
+        mock_optimizer = MockOptimizer(None, None)
+        self.optimizer._weighted_optimize = mock_optimizer.optimize
+        scaling_factors = self.optimizer.get_scaling_factors()
+        self.assertEqual([0.1, 0.1], scaling_factors)

--- a/itwm_example/mco/optimizers/tests/test_optimizers.py
+++ b/itwm_example/mco/optimizers/tests/test_optimizers.py
@@ -3,7 +3,6 @@ from unittest import TestCase
 from force_bdss.api import KPISpecification
 
 from itwm_example.mco.mco_factory import MCOFactory
-from itwm_example.mco.optimizers.optimizers import WeightedOptimizer
 from itwm_example.mco.space_sampling.space_samplers import (
     UniformSpaceSampler,
     DirichletSpaceSampler,
@@ -26,7 +25,7 @@ class TestWeightedOptimizer(TestCase):
             for _ in self.parameters
         ]
 
-        self.optimizer = WeightedOptimizer(None, self.mco_model)
+        self.optimizer = self.mco_model.optimizer
 
     def test__space_search_distribution(self):
         for strategy, klass in (
@@ -34,7 +33,7 @@ class TestWeightedOptimizer(TestCase):
             ("Dirichlet", DirichletSpaceSampler),
             ("Uniform", UniformSpaceSampler),
         ):
-            self.mco_model.space_search_mode = strategy
+            self.optimizer.space_search_mode = strategy
             distribution = self.optimizer._space_search_distribution()
             self.assertIsInstance(distribution, klass)
             self.assertEqual(len(self.kpis), distribution.dimension)

--- a/itwm_example/mco/optimizers/tests/test_optimizers.py
+++ b/itwm_example/mco/optimizers/tests/test_optimizers.py
@@ -8,7 +8,10 @@ from itwm_example.mco.space_sampling.space_samplers import (
     DirichletSpaceSampler,
 )
 from itwm_example.mco.tests.mock_classes import MockOptimizer
-from itwm_example.mco.optimizers.optimizers import WeightedOptimizer
+from itwm_example.mco.optimizers.optimizers import (
+    WeightedOptimizer,
+    NevergradOptimizer,
+)
 
 
 class TestWeightedOptimizer(TestCase):
@@ -76,3 +79,29 @@ class TestWeightedOptimizer(TestCase):
             },
             state,
         )
+
+
+class TestNevergradOptimizer(TestCase):
+    def setUp(self):
+        self.plugin = {"id": "pid", "name": "Plugin"}
+        self.factory = MCOFactory(self.plugin)
+        self.mco_model = self.factory.create_model()
+        self.mco_model.optimizer_mode = "NeverGrad"
+
+        self.kpis = [KPISpecification(), KPISpecification()]
+        self.parameters = [1, 1, 1, 1]
+
+        self.mco_model.kpis = self.kpis
+        self.mco_model.parameters = [
+            self.factory.parameter_factories[0].create_model()
+            for _ in self.parameters
+        ]
+
+        self.optimizer = self.mco_model.optimizer
+
+    def test_init(self):
+        self.assertIsInstance(self.optimizer, NevergradOptimizer)
+        self.assertEqual("Nevergrad", self.optimizer.name)
+        self.assertIs(self.optimizer.single_point_evaluator, None)
+        self.assertEqual("TwoPointsDE", self.optimizer.algorithms)
+        self.assertEqual(100, self.optimizer.budget)

--- a/itwm_example/mco/optimizers/tests/test_optimizers.py
+++ b/itwm_example/mco/optimizers/tests/test_optimizers.py
@@ -8,6 +8,7 @@ from itwm_example.mco.space_sampling.space_samplers import (
     DirichletSpaceSampler,
 )
 from itwm_example.mco.tests.mock_classes import MockOptimizer
+from itwm_example.mco.optimizers.optimizers import WeightedOptimizer
 
 
 class TestWeightedOptimizer(TestCase):
@@ -27,6 +28,14 @@ class TestWeightedOptimizer(TestCase):
 
         self.optimizer = self.mco_model.optimizer
 
+    def test_init(self):
+        self.assertIsInstance(self.optimizer, WeightedOptimizer)
+        self.assertEqual("Weighted_Optimizer", self.optimizer.name)
+        self.assertIs(self.optimizer.single_point_evaluator, None)
+        self.assertEqual("SLSQP", self.optimizer.algorithms)
+        self.assertEqual(7, self.optimizer.num_points)
+        self.assertEqual("Uniform", self.optimizer.space_search_mode)
+
     def test__space_search_distribution(self):
         for strategy, klass in (
             ("Uniform", UniformSpaceSampler),
@@ -39,6 +48,12 @@ class TestWeightedOptimizer(TestCase):
             self.assertEqual(len(self.kpis), distribution.dimension)
             self.assertEqual(7, distribution.resolution)
 
+    def test_scaling_factors(self):
+        mock_optimizer = MockOptimizer(None, None)
+        self.optimizer._weighted_optimize = mock_optimizer.optimize
+        scaling_factors = self.optimizer.get_scaling_factors()
+        self.assertEqual([0.1, 0.1], scaling_factors)
+
     def test_auto_scale(self):
         temp_kpis = [KPISpecification(), KPISpecification(auto_scale=False)]
         self.mco_model.kpis = temp_kpis
@@ -49,8 +64,15 @@ class TestWeightedOptimizer(TestCase):
         scaling_factors = self.optimizer.get_scaling_factors()
         self.assertEqual([0.1, 1.0], scaling_factors)
 
-    def test_scaling_factors(self):
-        mock_optimizer = MockOptimizer(None, None)
-        self.optimizer._weighted_optimize = mock_optimizer.optimize
-        scaling_factors = self.optimizer.get_scaling_factors()
-        self.assertEqual([0.1, 0.1], scaling_factors)
+    def test___getstate__(self):
+        state = self.optimizer.__getstate__()
+        self.assertDictEqual(
+            {
+                "name": "Weighted_Optimizer",
+                "single_point_evaluator": None,
+                "algorithms": "SLSQP",
+                "num_points": 7,
+                "space_search_mode": "Uniform",
+            },
+            state,
+        )

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -8,6 +8,10 @@ from force_bdss.api import (
 )
 
 from itwm_example.mco.mco_factory import MCOFactory
+from itwm_example.mco.optimizers.optimizers import (
+    WeightedOptimizer,
+    NevergradOptimizer,
+)
 
 
 class TestMCO(TestCase):
@@ -46,6 +50,48 @@ class TestMCO(TestCase):
             self.mco_model.optimizer._weighted_optimize([0.5, 0.5])
             self.assertEqual(7, mock_exec.call_count)
 
-    def test_change_optimizer(self):
+    def test_default_optimizer(self):
+        self.assertIsInstance(self.mco_model.optimizer, WeightedOptimizer)
+
+    def test_update_optimizer(self):
         self.mco_model.optimizer_mode = "NeverGrad"
+        self.assertIs(
+            self.mco_model._optimizer_from_mode(), NevergradOptimizer
+        )
+        self.assertIsInstance(self.mco_model.optimizer, NevergradOptimizer)
+        self.assertEqual(self.mco_model.optimizer.algorithms, "TwoPointsDE")
         self.mco_model.optimizer_mode = "Weighted"
+        self.assertIs(self.mco_model._optimizer_from_mode(), WeightedOptimizer)
+        self.assertIsInstance(self.mco_model.optimizer, WeightedOptimizer)
+        self.assertEqual(self.mco_model.optimizer.algorithms, "SLSQP")
+
+    def test_update_kpis(self):
+        new_kpis = [
+            KPISpecification(name="new"),
+            KPISpecification(name="another_new"),
+        ]
+        self.mco_model.kpis = new_kpis
+        self.assertEqual(self.mco_model.kpis, new_kpis)
+        self.assertEqual(self.mco_model.optimizer.kpis, new_kpis)
+
+    def test_update_parameters(self):
+        new_parameters = [2, 2, 2]
+        new_parameters = [
+            self.factory.parameter_factories[0].create_model()
+            for _ in new_parameters
+        ]
+        self.mco_model.parameters = new_parameters
+        self.assertEqual(self.mco_model.parameters, new_parameters)
+        self.assertEqual(self.mco_model.optimizer.parameters, new_parameters)
+
+    def test___getstate__(self):
+        state = self.mco_model.__getstate__()
+        self.assertEqual("Weighted", state["optimizer_mode"])
+        self.assertEqual("Weighted_Optimizer", state["optimizer_data"]["name"])
+        self.assertEqual("SLSQP", state["optimizer_data"]["algorithms"])
+
+        self.mco_model.optimizer_mode = "NeverGrad"
+        state = self.mco_model.__getstate__()
+        self.assertEqual("NeverGrad", state["optimizer_mode"])
+        self.assertEqual("Nevergrad", state["optimizer_data"]["name"])
+        self.assertEqual("TwoPointsDE", state["optimizer_data"]["algorithms"])

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -45,7 +45,7 @@ class TestMCO(TestCase):
         parameters = self.mco_model.parameters
 
         evaluator = self.mco.optimizer(
-            single_point_evaluator=self.evaluator, parameters=parameters
+            single_point_evaluator=self.evaluator, model=self.mco_model
         )
         mock_kpi_return = [DataValue(value=2), DataValue(value=3)]
 

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -37,13 +37,15 @@ class TestMCO(TestCase):
             self.mco.run(self.evaluator)
 
     def test_internal_weighted_evaluator(self):
-        evaluator = self.mco.optimizer(
-            single_point_evaluator=self.evaluator, model=self.mco_model
-        )
+        self.mco_model.optimizer.single_point_evaluator = self.evaluator
         mock_kpi_return = [DataValue(value=2), DataValue(value=3)]
 
         with mock.patch(
             "force_bdss.api.Workflow.execute", return_value=mock_kpi_return
         ) as mock_exec:
-            evaluator._weighted_optimize([0.5, 0.5])
+            self.mco_model.optimizer._weighted_optimize([0.5, 0.5])
             self.assertEqual(7, mock_exec.call_count)
+
+    def test_change_optimizer(self):
+        self.mco_model.optimizer_mode = "NeverGrad"
+        self.mco_model.optimizer_mode = "Weighted"

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -42,8 +42,6 @@ class TestMCO(TestCase):
             self.mco.run(self.evaluator)
 
     def test_internal_weighted_evaluator(self):
-        parameters = self.mco_model.parameters
-
         evaluator = self.mco.optimizer(
             single_point_evaluator=self.evaluator, model=self.mco_model
         )
@@ -52,7 +50,7 @@ class TestMCO(TestCase):
         with mock.patch(
             "force_bdss.api.Workflow.execute", return_value=mock_kpi_return
         ) as mock_exec:
-            evaluator.optimize([0.5, 0.5])
+            evaluator._weighted_optimize([0.5, 0.5])
             self.assertEqual(7, mock_exec.call_count)
 
     def test_scaling_factors(self):

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -32,6 +32,57 @@ class TestMCO(TestCase):
         self.evaluator = WorkflowEvaluator(workflow=Workflow())
         self.evaluator.workflow.mco = self.mco_model
 
+    def test_init_model(self):
+        model = self.factory.create_model()
+        self.assertEqual([], model.parameters)
+        self.assertEqual([], model.kpis)
+        self.assertEqual("Weighted", model.optimizer_mode)
+        self.assertIsInstance(model.optimizer, WeightedOptimizer)
+        self.assertListEqual(model.parameters, model.optimizer.parameters)
+        self.assertListEqual(model.kpis, model.optimizer.kpis)
+        self.assertEqual("SLSQP", model.optimizer.algorithms)
+
+        kpis = [KPISpecification(), KPISpecification()]
+        parameters = [
+            self.factory.parameter_factories[0].create_model()
+            for _ in [1, 1, 1, 1]
+        ]
+        optimizer_data = {"algorithms": "TNC", "num_points": 10}
+        model = self.factory.create_model(
+            {
+                "kpis": kpis,
+                "parameters": parameters,
+                "optimizer_data": optimizer_data,
+            }
+        )
+        self.assertListEqual(parameters, model.parameters)
+        self.assertListEqual(kpis, model.kpis)
+        self.assertEqual("Weighted", model.optimizer_mode)
+        self.assertIsInstance(model.optimizer, WeightedOptimizer)
+        self.assertListEqual(model.parameters, model.optimizer.parameters)
+        self.assertListEqual(model.kpis, model.optimizer.kpis)
+        self.assertEqual("TNC", model.optimizer.algorithms)
+        self.assertEqual(10, model.optimizer.num_points)
+
+        optimizer_mode = "NeverGrad"
+        optimizer_data = {"algorithms": "RandomSearch", "budget": 1000}
+        model = self.factory.create_model(
+            {
+                "kpis": kpis,
+                "parameters": parameters,
+                "optimizer_mode": optimizer_mode,
+                "optimizer_data": optimizer_data,
+            }
+        )
+        self.assertListEqual(parameters, model.parameters)
+        self.assertListEqual(kpis, model.kpis)
+        self.assertEqual("NeverGrad", model.optimizer_mode)
+        self.assertIsInstance(model.optimizer, NevergradOptimizer)
+        self.assertListEqual(model.parameters, model.optimizer.parameters)
+        self.assertListEqual(model.kpis, model.optimizer.kpis)
+        self.assertEqual("RandomSearch", model.optimizer.algorithms)
+        self.assertEqual(1000, model.optimizer.budget)
+
     def test_basic_eval(self):
         mock_kpi_return = [DataValue(value=2), DataValue(value=3)]
 

--- a/itwm_example/mco/tests/test_mco.py
+++ b/itwm_example/mco/tests/test_mco.py
@@ -7,12 +7,7 @@ from force_bdss.api import (
     WorkflowEvaluator,
 )
 
-from itwm_example.mco.tests.mock_classes import MockOptimizer
 from itwm_example.mco.mco_factory import MCOFactory
-from itwm_example.mco.space_sampling.space_samplers import (
-    UniformSpaceSampler,
-    DirichletSpaceSampler,
-)
 
 
 class TestMCO(TestCase):
@@ -52,32 +47,3 @@ class TestMCO(TestCase):
         ) as mock_exec:
             evaluator._weighted_optimize([0.5, 0.5])
             self.assertEqual(7, mock_exec.call_count)
-
-    def test_scaling_factors(self):
-        optimizer = MockOptimizer(self.evaluator, self.parameters)
-
-        scaling_factors = self.mco.get_scaling_factors(optimizer, self.kpis)
-
-        self.assertEqual([0.1, 0.1], scaling_factors)
-
-    def test_auto_scale(self):
-
-        temp_kpis = [KPISpecification(), KPISpecification(auto_scale=False)]
-
-        optimizer = MockOptimizer(self.evaluator, self.parameters)
-
-        scaling_factors = self.mco.get_scaling_factors(optimizer, temp_kpis)
-
-        self.assertEqual([0.1, 1.0], scaling_factors)
-
-    def test__space_search_distribution(self):
-        for strategy, klass in (
-            ("Uniform", UniformSpaceSampler),
-            ("Dirichlet", DirichletSpaceSampler),
-            ("Uniform", UniformSpaceSampler),
-        ):
-            self.mco_model.space_search_mode = strategy
-            distribution = self.mco._space_search_distribution(self.mco_model)
-            self.assertIsInstance(distribution, klass)
-            self.assertEqual(len(self.kpis), distribution.dimension)
-            self.assertEqual(7, distribution.resolution)


### PR DESCRIPTION
### Summary

This PR refactors and separates the responsibilities of `MCO` / `MCOModel` and `(Weighted)Optimizer` classes. We remove the optimizer-specific logic from the `MCO` and make it the optimizer's resposibility. We also provide an option to choose between different optimizers from `MCOModel`.

### Done

- We refactor all the `weights` logic from `MCO` into the `WeightedOptimizer` class. The entry point is the `WeightedOptimizer().optimize()` method, that yields optimal points and KPIs (and weights) that it could find. 

- We add a new gradient-free global optimizer `NevergradOptimizer`: the core functionality is provided by the [nevergrad project](https://github.com/facebookresearch/nevergrad). Please note that in order to run the example workflow ***it requires a patch** [that fixes this bug](https://github.com/facebookresearch/nevergrad/issues/346). ~UPD: a PR to fix this bug is under review to merge into master.~ UPD 6/12/2019: PR has been merged into master

- We implement UI functionality to switch between two optimizers: `NevergradOptimizer` and `WeightedOptimizer`, and read/write optimizer state to file.

- We test the `nevergrad.optimize` method with trivial examples to verify that all the constraints are taken into account, and that attributes of the optimizers are assigned properly.

### To do

- Make `MCOModel.optimizer` attribute a cached property that depends `optimizer_mode` and `optimizer_data`

- `nevergrad.instrumentation` can handle both numerical and categorical values. In this example we deal only with `Scalar` inputs. We have to implement a parser to create appropriate `instrumentation` (input search space)

### WIP

- Docs

### Notes

- Optimizer instance requires `kpis` and `parameters` objects to operate with. We throw them away when get the optimizer's state with `__getstate__`: this data is already serialised by the `MCOModel`. We don't want to duplicate this and deal with potential inconsistencies. 

- We assign the `single_point_evaluator` to the `IOptimizer` during the `MCO.run()`. We should think if this a sustainable decision.