### PR TITLE
MAINT: Using core force-bdss Ranged instead of Base MCOParameter

### DIFF
--- a/itwm_example/mco/mco_factory.py
+++ b/itwm_example/mco/mco_factory.py
@@ -3,7 +3,7 @@ from force_bdss.api import BaseMCOFactory
 from .mco_communicator import MCOCommunicator
 from .mco_model import MCOModel
 from .mco import MCO
-from .parameters import RangedMCOParameterFactory
+from .parameters import ITWMRangedMCOParameterFactory
 
 
 class MCOFactory(BaseMCOFactory):
@@ -28,5 +28,5 @@ class MCOFactory(BaseMCOFactory):
     #: Factory classes of the parameters the MCO supports.
     def get_parameter_factory_classes(self):
         return [
-            RangedMCOParameterFactory
+            ITWMRangedMCOParameterFactory
         ]

--- a/itwm_example/mco/parameters.py
+++ b/itwm_example/mco/parameters.py
@@ -1,36 +1,20 @@
 from traits.api import Float
 
-from force_bdss.api import (
-    BaseMCOParameter,
-    BaseMCOParameterFactory)
+from force_bdss.mco.parameters.mco_parameters import (
+    RangedMCOParameterFactory,
+    RangedMCOParameter,
+)
 
 
-class RangedMCOParameter(BaseMCOParameter):
-    """Expresses a MCO parameter that has a range between two floating
-    point values."""
+class ITWMRangedMCOParameter(RangedMCOParameter):
+    """ Ranged MCO parameter with an initial value."""
+
     initial_value = Float(0.0)
-    lower_bound = Float(0.0)
-    upper_bound = Float(1.0)
 
 
-class RangedMCOParameterFactory(BaseMCOParameterFactory):
+class ITWMRangedMCOParameterFactory(RangedMCOParameterFactory):
     """The factory of the above model"""
-    #: This identifier must be unique for your parameter.
-    #: Once again you are fully responsible for its uniqueness within the scope
-    #: of the MCO it belongs to. You can have the same identifier if and only
-    #: if they belong to different MCOs.
-    #: Again, you are free to choose a uuid if you so prefer.
-    def get_identifier(self):
-        return "ranged"
-
-    #: A name that will appear in the UI to identify this parameter.
-    def get_name(self):
-        return "Range"
 
     #: Definition of the associated model class.
     def get_model_class(self):
-        return RangedMCOParameter
-
-    #: A long description of the parameter
-    def get_description(self):
-        return "A ranged parameter in floating point values."
+        return ITWMRangedMCOParameter

--- a/itwm_example/mco/parameters.py
+++ b/itwm_example/mco/parameters.py
@@ -18,3 +18,9 @@ class ITWMRangedMCOParameterFactory(RangedMCOParameterFactory):
     #: Definition of the associated model class.
     def get_model_class(self):
         return ITWMRangedMCOParameter
+
+    #: A long description of the parameter
+    def get_description(self):
+        _desc = super().get_description()
+        _desc += " Initial value is assigned by `Parameter.initial_value`."
+        return _desc


### PR DESCRIPTION
Following the recent updates to `force-bdss` functionality, we refactor the `MCOParameter` and factory classes in the ITWM example:

- Now the `MCOParameter` and `MCOParameterFactory` in this example plugin inherit from the BDSS `RangedMCOParameter` entities
- The new `ITWMRangedMCOParameter` class adds and `initial_value` for WeightedOptimizer calculations

We suggest user to inherit from the existing force-bdss Parameter objects when possible, and to add necessary functionality in their plugins.