### PR TITLE
FIX: renamed the deprecated workflow.mco to workflow.mco_model

### DIFF
--- a/itwm_example/mco/tests/test_weighted_mco.py
+++ b/itwm_example/mco/tests/test_weighted_mco.py
@@ -91,7 +91,7 @@ class TestWeightedMCO(TestCase, UnittestTools):
         evaluator = WorkflowEvaluator(
             workflow=Workflow(), workflow_filepath="whatever"
         )
-        evaluator.workflow.mco = model
+        evaluator.workflow.mco_model = model
         kpis = [DataValue(value=1), DataValue(value=2)]
         with self.assertTraitChanges(mco, "event", count=model.num_points - 2):
             with mock.patch(

--- a/itwm_example/tests/fixtures/itwm_nevergrad_mco.json
+++ b/itwm_example/tests/fixtures/itwm_nevergrad_mco.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco": {
+        "mco_model": {
             "id": "force.bdss.nevergrad.plugin.wrapper.v0.factory.nevergrad_mco",
             "model_data": {
                 "budget": 200,

--- a/itwm_example/tests/fixtures/itwm_weighted_mco.json
+++ b/itwm_example/tests/fixtures/itwm_weighted_mco.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco": {
+        "mco_model": {
             "id": "force.bdss.itwm.plugin.example.v0.factory.weighted_mco",
             "model_data": {
                 "evaluation_mode": "Internal",


### PR DESCRIPTION
This PR fixes the reference to `Workflow.mco` which was changed in [#257](https://github.com/force-h2020/force-bdss/pull/257).