### PR TITLE
FIX: Minor fix to example workflow files

### DIFF
--- a/itwm_example/tests/fixtures/itwm_nevergrad_mco.json
+++ b/itwm_example/tests/fixtures/itwm_nevergrad_mco.json
@@ -1,17 +1,20 @@
 {
-    "version": "1",
+    "version": "1.1",
     "workflow": {
-        "mco": {
+        "mco_model": {
             "id": "force.bdss.nevergrad.plugin.wrapper.v0.factory.nevergrad_mco",
             "model_data": {
+                "algorithms": "TwoPointsDE",
                 "budget": 200,
+                "verbose_run": true,
                 "parameters": [
                     {
                         "id": "force.bdss.nevergrad.plugin.wrapper.v0.factory.nevergrad_mco.parameter.ranged",
                         "model_data": {
-                            "initial_value": 0.49,
                             "lower_bound": 0.01,
                             "upper_bound": 1.0,
+                            "initial_value": 0.49,
+                            "n_samples": 5,
                             "name": "volume_a_tilde",
                             "type": "VOLUME"
                         }
@@ -19,9 +22,10 @@
                     {
                         "id": "force.bdss.nevergrad.plugin.wrapper.v0.factory.nevergrad_mco.parameter.ranged",
                         "model_data": {
-                            "initial_value": 0.08,
                             "lower_bound": 0.001,
                             "upper_bound": 0.1,
+                            "initial_value": 0.08,
+                            "n_samples": 5,
                             "name": "conc_e",
                             "type": "CONCENTRATION"
                         }
@@ -29,9 +33,10 @@
                     {
                         "id": "force.bdss.nevergrad.plugin.wrapper.v0.factory.nevergrad_mco.parameter.ranged",
                         "model_data": {
-                            "initial_value": 350.0,
                             "lower_bound": 270.0,
                             "upper_bound": 400.0,
+                            "initial_value": 350.0,
+                            "n_samples": 5,
                             "name": "temperature",
                             "type": "TEMPERATURE"
                         }
@@ -39,9 +44,10 @@
                     {
                         "id": "force.bdss.nevergrad.plugin.wrapper.v0.factory.nevergrad_mco.parameter.ranged",
                         "model_data": {
-                            "initial_value": 2670.0,
                             "lower_bound": 1.0,
                             "upper_bound": 3600.0,
+                            "initial_value": 2670.0,
+                            "n_samples": 5,
                             "name": "reaction_time",
                             "type": "TIME"
                         }
@@ -70,189 +76,193 @@
             }
         },
         "execution_layers": [
-            [
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.arrhenius_parameters",
-                    "model_data": {
-                        "nu_main_reaction": 0.02,
-                        "delta_H_main_reaction": 1.5,
-                        "nu_secondary_reaction": 0.02,
-                        "delta_H_secondary_reaction": 12.0,
-                        "input_slot_info": [],
-                        "output_slot_info": [
-                            {
-                                "name": "arr_nu_main"
-                            },
-                            {
-                                "name": "arr_dh_main"
-                            },
-                            {
-                                "name": "arr_nu_sec"
-                            },
-                            {
-                                "name": "arr_dh_sec"
-                            }
-                        ]
+            {
+                "data_sources": [
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.arrhenius_parameters",
+                        "model_data": {
+                            "nu_main_reaction": 0.02,
+                            "delta_H_main_reaction": 1.5,
+                            "nu_secondary_reaction": 0.02,
+                            "delta_H_secondary_reaction": 12.0,
+                            "input_slot_info": [],
+                            "output_slot_info": [
+                                {
+                                    "name": "arr_nu_main"
+                                },
+                                {
+                                    "name": "arr_dh_main"
+                                },
+                                {
+                                    "name": "arr_nu_sec"
+                                },
+                                {
+                                    "name": "arr_dh_sec"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.pure_densities",
+                        "model_data": {
+                            "a_pure_density": 1.0,
+                            "b_pure_density": 1.0,
+                            "c_pure_density": 1.0,
+                            "input_slot_info": [],
+                            "output_slot_info": [
+                                {
+                                    "name": "a_density"
+                                },
+                                {
+                                    "name": "b_density"
+                                },
+                                {
+                                    "name": "c_density"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.fixed_value_data_source",
+                        "model_data": {
+                            "value": 1.0,
+                            "cuba_type_out": "VOLUME",
+                            "input_slot_info": [],
+                            "output_slot_info": [
+                                {
+                                    "name": "reactor_volume"
+                                }
+                            ]
+                        }
                     }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.pure_densities",
-                    "model_data": {
-                        "a_pure_density": 1.0,
-                        "b_pure_density": 1.0,
-                        "c_pure_density": 1.0,
-                        "input_slot_info": [],
-                        "output_slot_info": [
-                            {
-                                "name": "a_density"
-                            },
-                            {
-                                "name": "b_density"
-                            },
-                            {
-                                "name": "c_density"
-                            }
-                        ]
+                ]
+            },
+            {
+                "data_sources": [
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.impurity_concentration",
+                        "model_data": {
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "volume_a_tilde"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "conc_e"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "temperature"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reaction_time"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_nu_main"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_dh_main"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_nu_sec"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_dh_sec"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reactor_volume"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "a_density"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "b_density"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "c_density"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "impurity_conc"
+                                },
+                                {
+                                    "name": "impurity_conc_grad"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.material_cost_data_source",
+                        "model_data": {
+                            "const_A": 1.0,
+                            "const_C": 1.0,
+                            "cost_B": 1.0,
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "volume_a_tilde"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "conc_e"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reactor_volume"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "c_density"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "mat_cost"
+                                },
+                                {
+                                    "name": "mat_cost_grad"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.production_cost_data_source",
+                        "model_data": {
+                            "W": 1.0,
+                            "temperature_shift": 20.0,
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "temperature"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reaction_time"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "prod_cost"
+                                },
+                                {
+                                    "name": "prod_cost_grad"
+                                }
+                            ]
+                        }
                     }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.fixed_value_data_source",
-                    "model_data": {
-                        "value": 1.0,
-                        "cuba_type_out": "VOLUME",
-                        "input_slot_info": [],
-                        "output_slot_info": [
-                            {
-                                "name": "reactor_volume"
-                            }
-                        ]
-                    }
-                }
-            ],
-            [
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.impurity_concentration",
-                    "model_data": {
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "volume_a_tilde"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "conc_e"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "temperature"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reaction_time"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_nu_main"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_dh_main"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_nu_sec"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_dh_sec"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reactor_volume"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "a_density"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "b_density"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "c_density"
-                            }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "impurity_conc"
-                            },
-                            {
-                                "name": "impurity_conc_grad"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.material_cost_data_source",
-                    "model_data": {
-                        "const_A": 1.0,
-                        "const_C": 1.0,
-                        "cost_B": 1.0,
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "volume_a_tilde"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "conc_e"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reactor_volume"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "c_density"
-                            }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "mat_cost"
-                            },
-                            {
-                                "name": "mat_cost_grad"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.production_cost_data_source",
-                    "model_data": {
-                        "W": 1.0,
-                        "temperature_shift": 20.0,
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "temperature"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reaction_time"
-                            }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "prod_cost"
-                            },
-                            {
-                                "name": "prod_cost_grad"
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         ],
         "notification_listeners": [
             {

--- a/itwm_example/tests/fixtures/itwm_nevergrad_mco.json
+++ b/itwm_example/tests/fixtures/itwm_nevergrad_mco.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco_model": {
+        "mco": {
             "id": "force.bdss.nevergrad.plugin.wrapper.v0.factory.nevergrad_mco",
             "model_data": {
                 "budget": 200,

--- a/itwm_example/tests/fixtures/itwm_weighted_mco.json
+++ b/itwm_example/tests/fixtures/itwm_weighted_mco.json
@@ -1,9 +1,13 @@
 {
-    "version": "1",
+    "version": "1.1",
     "workflow": {
-        "mco": {
+        "mco_model": {
             "id": "force.bdss.itwm.plugin.example.v0.factory.weighted_mco",
             "model_data": {
+                "algorithms": "SLSQP",
+                "num_points": 7,
+                "verbose_run": true,
+                "space_search_mode": "Uniform",
                 "evaluation_mode": "Internal",
                 "parameters": [
                     {
@@ -12,6 +16,7 @@
                             "initial_value": 0.49,
                             "lower_bound": 0.01,
                             "upper_bound": 1.0,
+                            "n_samples": 5,
                             "name": "volume_a_tilde",
                             "type": "VOLUME"
                         }
@@ -22,6 +27,7 @@
                             "initial_value": 0.08,
                             "lower_bound": 0.001,
                             "upper_bound": 0.1,
+                            "n_samples": 5,
                             "name": "conc_e",
                             "type": "CONCENTRATION"
                         }
@@ -32,6 +38,7 @@
                             "initial_value": 350.0,
                             "lower_bound": 270.0,
                             "upper_bound": 400.0,
+                            "n_samples": 5,
                             "name": "temperature",
                             "type": "TEMPERATURE"
                         }
@@ -42,6 +49,7 @@
                             "initial_value": 2670.0,
                             "lower_bound": 1.0,
                             "upper_bound": 3600.0,
+                            "n_samples": 5,
                             "name": "reaction_time",
                             "type": "TIME"
                         }
@@ -70,189 +78,193 @@
             }
         },
         "execution_layers": [
-            [
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.arrhenius_parameters",
-                    "model_data": {
-                        "nu_main_reaction": 0.02,
-                        "delta_H_main_reaction": 1.5,
-                        "nu_secondary_reaction": 0.02,
-                        "delta_H_secondary_reaction": 12.0,
-                        "input_slot_info": [],
-                        "output_slot_info": [
-                            {
-                                "name": "arr_nu_main"
-                            },
-                            {
-                                "name": "arr_dh_main"
-                            },
-                            {
-                                "name": "arr_nu_sec"
-                            },
-                            {
-                                "name": "arr_dh_sec"
-                            }
-                        ]
+            {
+                "data_sources": [
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.arrhenius_parameters",
+                        "model_data": {
+                            "nu_main_reaction": 0.02,
+                            "delta_H_main_reaction": 1.5,
+                            "nu_secondary_reaction": 0.02,
+                            "delta_H_secondary_reaction": 12.0,
+                            "input_slot_info": [],
+                            "output_slot_info": [
+                                {
+                                    "name": "arr_nu_main"
+                                },
+                                {
+                                    "name": "arr_dh_main"
+                                },
+                                {
+                                    "name": "arr_nu_sec"
+                                },
+                                {
+                                    "name": "arr_dh_sec"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.pure_densities",
+                        "model_data": {
+                            "a_pure_density": 1.0,
+                            "b_pure_density": 1.0,
+                            "c_pure_density": 1.0,
+                            "input_slot_info": [],
+                            "output_slot_info": [
+                                {
+                                    "name": "a_density"
+                                },
+                                {
+                                    "name": "b_density"
+                                },
+                                {
+                                    "name": "c_density"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.fixed_value_data_source",
+                        "model_data": {
+                            "value": 1.0,
+                            "cuba_type_out": "VOLUME",
+                            "input_slot_info": [],
+                            "output_slot_info": [
+                                {
+                                    "name": "reactor_volume"
+                                }
+                            ]
+                        }
                     }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.pure_densities",
-                    "model_data": {
-                        "a_pure_density": 1.0,
-                        "b_pure_density": 1.0,
-                        "c_pure_density": 1.0,
-                        "input_slot_info": [],
-                        "output_slot_info": [
-                            {
-                                "name": "a_density"
-                            },
-                            {
-                                "name": "b_density"
-                            },
-                            {
-                                "name": "c_density"
-                            }
-                        ]
+                ]
+            },
+            {
+                "data_sources": [
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.impurity_concentration",
+                        "model_data": {
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "volume_a_tilde"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "conc_e"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "temperature"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reaction_time"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_nu_main"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_dh_main"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_nu_sec"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "arr_dh_sec"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reactor_volume"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "a_density"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "b_density"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "c_density"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "impurity_conc"
+                                },
+                                {
+                                    "name": "impurity_conc_grad"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.material_cost_data_source",
+                        "model_data": {
+                            "const_A": 1.0,
+                            "const_C": 1.0,
+                            "cost_B": 1.0,
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "volume_a_tilde"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "conc_e"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reactor_volume"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "c_density"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "mat_cost"
+                                },
+                                {
+                                    "name": "mat_cost_grad"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "force.bdss.itwm.plugin.example.v0.factory.production_cost_data_source",
+                        "model_data": {
+                            "W": 1.0,
+                            "temperature_shift": 20.0,
+                            "input_slot_info": [
+                                {
+                                    "source": "Environment",
+                                    "name": "temperature"
+                                },
+                                {
+                                    "source": "Environment",
+                                    "name": "reaction_time"
+                                }
+                            ],
+                            "output_slot_info": [
+                                {
+                                    "name": "prod_cost"
+                                },
+                                {
+                                    "name": "prod_cost_grad"
+                                }
+                            ]
+                        }
                     }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.fixed_value_data_source",
-                    "model_data": {
-                        "value": 1.0,
-                        "cuba_type_out": "VOLUME",
-                        "input_slot_info": [],
-                        "output_slot_info": [
-                            {
-                                "name": "reactor_volume"
-                            }
-                        ]
-                    }
-                }
-            ],
-            [
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.impurity_concentration",
-                    "model_data": {
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "volume_a_tilde"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "conc_e"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "temperature"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reaction_time"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_nu_main"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_dh_main"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_nu_sec"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "arr_dh_sec"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reactor_volume"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "a_density"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "b_density"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "c_density"
-                            }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "impurity_conc"
-                            },
-                            {
-                                "name": "impurity_conc_grad"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.material_cost_data_source",
-                    "model_data": {
-                        "const_A": 1.0,
-                        "const_C": 1.0,
-                        "cost_B": 1.0,
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "volume_a_tilde"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "conc_e"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reactor_volume"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "c_density"
-                            }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "mat_cost"
-                            },
-                            {
-                                "name": "mat_cost_grad"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "id": "force.bdss.itwm.plugin.example.v0.factory.production_cost_data_source",
-                    "model_data": {
-                        "W": 1.0,
-                        "temperature_shift": 20.0,
-                        "input_slot_info": [
-                            {
-                                "source": "Environment",
-                                "name": "temperature"
-                            },
-                            {
-                                "source": "Environment",
-                                "name": "reaction_time"
-                            }
-                        ],
-                        "output_slot_info": [
-                            {
-                                "name": "prod_cost"
-                            },
-                            {
-                                "name": "prod_cost_grad"
-                            }
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         ],
         "notification_listeners": [
             {

--- a/itwm_example/tests/fixtures/itwm_weighted_mco.json
+++ b/itwm_example/tests/fixtures/itwm_weighted_mco.json
@@ -1,7 +1,7 @@
 {
     "version": "1",
     "workflow": {
-        "mco_model": {
+        "mco": {
             "id": "force.bdss.itwm.plugin.example.v0.factory.weighted_mco",
             "model_data": {
                 "evaluation_mode": "Internal",


### PR DESCRIPTION
Since https://github.com/force-h2020/force-bdss/pull/287, workflow files now need to adhere to strict formatting between version 1 and 1.1.

The example current files in `item_example/tests/fixtures` contained mixtures of both 1 and 1.1 formatting. 

This PR fixes them at version 1.1 formatting.