### PR TITLE
CI: Upgraded EDM version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,27 @@
 language: c
+
+env:
+  global:
+    - EDM_FULL=2.1.0
+      EDM_X_Y=2.1
+
+matrix:
+  include:
+  - os: linux
+    dist: bionic
+    services:
+      - xvfb
+    env:
+      - EDM_OS="rh6_x86_64"
+      - EDM_INSTALLER_PREFIX="edm_cli_"
+        EDM_INSTALLER_SUFFIX="_linux_x86_64.sh"
+  - os: osx
+    env:
+      - EDM_OS="osx_x86_64"
+      - EDM_INSTALLER_PREFIX="edm_"
+        EDM_INSTALLER_SUFFIX=".pkg"
+
+
 cache:
   directories:
       - "$HOME/.cache"
@@ -6,8 +29,12 @@ cache:
 before_install:
     - ccache -s
     - export PATH=/usr/lib/ccache:${PATH}
-    - wget https://package-data.enthought.com/edm/rh5_x86_64/1.9/edm_1.9.2_linux_x86_64.sh && bash ./edm_1.9.2_linux_x86_64.sh -b -f -p $HOME
-    - export PATH=${HOME}/edm/bin:${PATH}
+    - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
+    - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./${EDM_INSTALLER} -b -f -p $HOME ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]] ; then sudo installer -pkg ./${EDM_INSTALLER} -target / ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install --version 3.6 -y click setuptools
     - git clone git://github.com/force-h2020/force-bdss.git
     - pushd force-bdss
@@ -19,8 +46,6 @@ script:
     - edm run -- python -m ci flake8
     - edm run -- python -m ci test
 after_success:
-    - edm run -- python -m ci coverage
-    - edm run -- pip install codecov
-    - edm run -- codecov
-    - bash <(curl -s https://codecov.io/bash)
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then edm run -- python -m ci coverage; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash <(curl -s https://codecov.io/bash); fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ cache:
       - "$HOME/.cache"
       - "$HOME/.ccache"
 before_install:
-    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then ccache -s
-    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=/usr/lib/ccache:${PATH}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then ccache -s ; fi
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=/usr/lib/ccache:${PATH} ; fi
     - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./${EDM_INSTALLER} -b -f -p $HOME ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ cache:
       - "$HOME/.cache"
       - "$HOME/.ccache"
 before_install:
-    - ccache -s
-    - export PATH=/usr/lib/ccache:${PATH}
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then ccache -s
+    - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=/usr/lib/ccache:${PATH}
     - export EDM_INSTALLER=${EDM_INSTALLER_PREFIX}${EDM_FULL}${EDM_INSTALLER_SUFFIX}
     - wget https://package-data.enthought.com/edm/${EDM_OS}/${EDM_X_Y}/${EDM_INSTALLER}
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then bash ./${EDM_INSTALLER} -b -f -p $HOME ; fi


### PR DESCRIPTION
This PR is a duplicate of #76 

This PR upgrades the `edm` version to `2.1.0`, which is used for BDSS and WfManager.