### PR TITLE
DEV: Bump to Version 0.4.0.dev0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 CHANGELOG
 ---------
 
+Version 0.4.0
+-------------
+
 Version 0.3.0
 -------------
 
-Released:
+Released: 24 Feb 2020
 
 Release notes
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "0.3.0"
+VERSION = "0.4.0.dev0"
 
 
 # Read description


### PR DESCRIPTION
This PR bumps the current plugin version to `0.4.0.dev0`