### PR TITLE
DOC/FIX: Small fixes to Sphinx Makefile and unit tests

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -187,4 +187,4 @@ uml:
 .PHONY: apidoc
 apidoc:
 	-rm -rf source/api/
-	sphinx-apidoc -H 'Enthought plugins' -M -o source/api ../ ../setup.py ../ci ../*tests*
+	sphinx-apidoc -o source/api ../itwm_example

--- a/itwm_example/mco/tests/test_weighted_mco.py
+++ b/itwm_example/mco/tests/test_weighted_mco.py
@@ -98,9 +98,9 @@ class TestWeightedMCO(TestCase, UnittestTools):
         kpis = [DataValue(value=1), DataValue(value=2)]
         with self.assertTraitChanges(evaluator.mco_model,
                                      "event",
-                                     count=model.num_points - 2):
+                                     count=model.num_points):
             with mock.patch(
                 "force_bdss.api.Workflow.execute", return_value=kpis
             ) as mock_exec:
                 mco.run(evaluator)
-                self.assertEqual(49, mock_exec.call_count)
+                self.assertEqual(63, mock_exec.call_count)


### PR DESCRIPTION
This PR provides 2 minor fixes:

- Changes the documentation Sphinx build to only look through files in the `itwm_example` module.
- Updates to the unit tests that were needed to be introduced after https://github.com/force-h2020/force-bdss/pull/336

**NOTE:** Although the previous Sphinx behaviour appeared innocuous, it would result in sphinx building documentation from any additional folders installed included in the `force-bdss-plugin-itwm-example` directory. This occurs in our Travis build for example, when we clone the `force-bdss` repository, and was therefore leading to build failures in #81.

