### PR TITLE
ehthought copyright headers

### DIFF
--- a/ci/__init__.py
+++ b/ci/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import click
 import subprocess
 from subprocess import check_call

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import sphinx.environment
 from docutils.utils import get_source_line
 import sys

--- a/itwm_example/__init__.py
+++ b/itwm_example/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/arrhenius_parameters/__init__.py
+++ b/itwm_example/arrhenius_parameters/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/arrhenius_parameters/arrhenius_parameters.py
+++ b/itwm_example/arrhenius_parameters/arrhenius_parameters.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSource, DataValue, Slot
 
 

--- a/itwm_example/arrhenius_parameters/arrhenius_parameters_factory.py
+++ b/itwm_example/arrhenius_parameters/arrhenius_parameters_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSourceFactory
 
 from .arrhenius_parameters_model import ArrheniusParametersModel

--- a/itwm_example/arrhenius_parameters/arrhenius_parameters_model.py
+++ b/itwm_example/arrhenius_parameters/arrhenius_parameters_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float
 from traitsui.api import View, Item
 

--- a/itwm_example/arrhenius_parameters/tests/__init__.py
+++ b/itwm_example/arrhenius_parameters/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/arrhenius_parameters/tests/test_arrhenius_parameters.py
+++ b/itwm_example/arrhenius_parameters/tests/test_arrhenius_parameters.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.tests.template_test_classes.template_test_data_source \
     import TemplateTestDataSource
 

--- a/itwm_example/csv_writer/__init__.py
+++ b/itwm_example/csv_writer/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/csv_writer/csv_writer.py
+++ b/itwm_example/csv_writer/csv_writer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseCSVWriterFactory
 
 

--- a/itwm_example/csv_writer/tests/__init__.py
+++ b/itwm_example/csv_writer/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/csv_writer/tests/test_csv_writer.py
+++ b/itwm_example/csv_writer/tests/test_csv_writer.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from force_bdss.api import (

--- a/itwm_example/fixed_value_data_source/__init__.py
+++ b/itwm_example/fixed_value_data_source/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/fixed_value_data_source/fixed_value_data_source.py
+++ b/itwm_example/fixed_value_data_source/fixed_value_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSource, DataValue, Slot
 
 

--- a/itwm_example/fixed_value_data_source/fixed_value_data_source_factory.py
+++ b/itwm_example/fixed_value_data_source/fixed_value_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSourceFactory
 
 from .fixed_value_data_source_model import FixedValueDataSourceModel

--- a/itwm_example/fixed_value_data_source/fixed_value_data_source_model.py
+++ b/itwm_example/fixed_value_data_source/fixed_value_data_source_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float, Unicode, on_trait_change
 
 from force_bdss.api import BaseDataSourceModel

--- a/itwm_example/fixed_value_data_source/tests/__init__.py
+++ b/itwm_example/fixed_value_data_source/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/fixed_value_data_source/tests/test_fixed_value_data_source.py
+++ b/itwm_example/fixed_value_data_source/tests/test_fixed_value_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.tests.template_test_classes.template_test_data_source \
     import TemplateTestDataSource
 

--- a/itwm_example/impurity_concentration/__init__.py
+++ b/itwm_example/impurity_concentration/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/impurity_concentration/impurity_concentration_data_source.py
+++ b/itwm_example/impurity_concentration/impurity_concentration_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import numpy as np
 from scipy.special import factorial
 

--- a/itwm_example/impurity_concentration/impurity_concentration_data_source_factory.py
+++ b/itwm_example/impurity_concentration/impurity_concentration_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.data_sources.base_data_source_factory import \
     BaseDataSourceFactory
 from itwm_example.impurity_concentration.impurity_concentration_data_source \

--- a/itwm_example/impurity_concentration/impurity_concentration_data_source_model.py
+++ b/itwm_example/impurity_concentration/impurity_concentration_data_source_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.data_sources.base_data_source_model import BaseDataSourceModel
 
 

--- a/itwm_example/impurity_concentration/tests/__init__.py
+++ b/itwm_example/impurity_concentration/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/impurity_concentration/tests/test_impurity_concentration_data_source.py
+++ b/itwm_example/impurity_concentration/tests/test_impurity_concentration_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.tests.template_test_classes.template_test_data_source \
     import TemplateTestGradientDataSource
 

--- a/itwm_example/itwm_example_plugin.py
+++ b/itwm_example/itwm_example_plugin.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.mco.weighted_mco_factory import WeightedMCOFactory
 from itwm_example.pure_densities.pure_densities_factory import \
     PureDensitiesFactory

--- a/itwm_example/material_cost_data_source/__init__.py
+++ b/itwm_example/material_cost_data_source/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/material_cost_data_source/material_cost_data_source.py
+++ b/itwm_example/material_cost_data_source/material_cost_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSource, DataValue, Slot
 
 

--- a/itwm_example/material_cost_data_source/material_cost_data_source_factory.py
+++ b/itwm_example/material_cost_data_source/material_cost_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSourceFactory
 from itwm_example.material_cost_data_source.material_cost_data_source import \
     MaterialCostDataSource

--- a/itwm_example/material_cost_data_source/material_cost_data_source_model.py
+++ b/itwm_example/material_cost_data_source/material_cost_data_source_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float
 
 from force_bdss.api import BaseDataSourceModel

--- a/itwm_example/material_cost_data_source/tests/__init__.py
+++ b/itwm_example/material_cost_data_source/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/material_cost_data_source/tests/test_material_cost_data_source.py
+++ b/itwm_example/material_cost_data_source/tests/test_material_cost_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.tests.template_test_classes.template_test_data_source \
     import TemplateTestGradientDataSource
 

--- a/itwm_example/mco/__init__.py
+++ b/itwm_example/mco/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/mco/driver_events.py
+++ b/itwm_example/mco/driver_events.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import MCOStartEvent
 
 

--- a/itwm_example/mco/parameters.py
+++ b/itwm_example/mco/parameters.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float
 
 from force_bdss.mco.parameters.mco_parameters import (

--- a/itwm_example/mco/tests/__init__.py
+++ b/itwm_example/mco/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/mco/tests/mock_classes.py
+++ b/itwm_example/mco/tests/mock_classes.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import numpy as np
 
 

--- a/itwm_example/mco/tests/test_driver_events.py
+++ b/itwm_example/mco/tests/test_driver_events.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase
 
 from itwm_example.mco.driver_events import ITWMMCOStartEvent

--- a/itwm_example/mco/tests/test_weighted_mco.py
+++ b/itwm_example/mco/tests/test_weighted_mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from unittest import TestCase, mock
 
 from traits.testing.unittest_tools import UnittestTools

--- a/itwm_example/mco/weighted_mco.py
+++ b/itwm_example/mco/weighted_mco.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import logging
 
 from force_bdss.api import BaseMCO, DataValue

--- a/itwm_example/mco/weighted_mco_factory.py
+++ b/itwm_example/mco/weighted_mco_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import (
     BaseMCOFactory,
     FixedMCOParameterFactory,

--- a/itwm_example/mco/weighted_mco_model.py
+++ b/itwm_example/mco/weighted_mco_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Enum, Bool
 from traitsui.api import View, Item
 

--- a/itwm_example/production_cost_data_source/__init__.py
+++ b/itwm_example/production_cost_data_source/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/production_cost_data_source/production_cost_data_source.py
+++ b/itwm_example/production_cost_data_source/production_cost_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSource, DataValue, Slot
 
 

--- a/itwm_example/production_cost_data_source/production_cost_data_source_factory.py
+++ b/itwm_example/production_cost_data_source/production_cost_data_source_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSourceFactory
 
 from .production_cost_data_source_model import ProductionCostDataSourceModel

--- a/itwm_example/production_cost_data_source/production_cost_data_source_model.py
+++ b/itwm_example/production_cost_data_source/production_cost_data_source_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float
 
 from force_bdss.api import BaseDataSourceModel

--- a/itwm_example/production_cost_data_source/tests/__init__.py
+++ b/itwm_example/production_cost_data_source/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/production_cost_data_source/tests/test_production_cost_data_source.py
+++ b/itwm_example/production_cost_data_source/tests/test_production_cost_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.tests.template_test_classes.template_test_data_source \
     import TemplateTestGradientDataSource
 

--- a/itwm_example/pure_densities/__init__.py
+++ b/itwm_example/pure_densities/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/pure_densities/pure_densities.py
+++ b/itwm_example/pure_densities/pure_densities.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from force_bdss.api import BaseDataSource, DataValue, Slot
 
 

--- a/itwm_example/pure_densities/pure_densities_factory.py
+++ b/itwm_example/pure_densities/pure_densities_factory.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.pure_densities.pure_densities import PureDensities
 from itwm_example.pure_densities.pure_densities_model import PureDensitiesModel
 

--- a/itwm_example/pure_densities/pure_densities_model.py
+++ b/itwm_example/pure_densities/pure_densities_model.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from traits.api import Float
 from traitsui.api import View, Item
 

--- a/itwm_example/pure_densities/tests/__init__.py
+++ b/itwm_example/pure_densities/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/pure_densities/tests/test_pure_densities.py
+++ b/itwm_example/pure_densities/tests/test_pure_densities.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from itwm_example.tests.template_test_classes.template_test_data_source \
     import TemplateTestDataSource
 

--- a/itwm_example/tests/__init__.py
+++ b/itwm_example/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/tests/template_test_classes/template_test_data_source.py
+++ b/itwm_example/tests/template_test_classes/template_test_data_source.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import inspect
 import unittest
 

--- a/itwm_example/unittest_tools/__init__.py
+++ b/itwm_example/unittest_tools/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/unittest_tools/gradient_consistency/__init__.py
+++ b/itwm_example/unittest_tools/gradient_consistency/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/unittest_tools/gradient_consistency/taylor_convergence.py
+++ b/itwm_example/unittest_tools/gradient_consistency/taylor_convergence.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 from scipy.stats import linregress
 import numpy as np
 

--- a/itwm_example/unittest_tools/gradient_consistency/tests/__init__.py
+++ b/itwm_example/unittest_tools/gradient_consistency/tests/__init__.py
@@ -1,0 +1,2 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.

--- a/itwm_example/unittest_tools/gradient_consistency/tests/test_taylor_convergence.py
+++ b/itwm_example/unittest_tools/gradient_consistency/tests/test_taylor_convergence.py
@@ -1,3 +1,6 @@
+#  (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
+#  All rights reserved.
+
 import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal


### PR DESCRIPTION
## Description
Add Enthought open source copyright header to every file.

## Related Issues
https://github.com/force-h2020/force-bdss/pull/351

### Notes
The headers were inserted automatically using PyCharm's Copyright Profile functionality. The only problem is that it ends up creating two blank lines at the end of blank  _init_.py module files, which then don't pass flake8, so the extra line has to be removed manually.

## Changes
Just the header on each file