### PR TITLE
TST/FIX: Include KPI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then export PATH=${HOME}/edm/bin:${PATH} ; fi
     - if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then export PATH="${PATH}:/usr/local/bin" ; fi
     - edm install -y --version 3.6 click setuptools
-    - git clone git://github.com/force-h2020/force-bdss.git
+    - git clone git://github.com/force-h2020/force-bdss.git -b enh/kpi-attr
     - pushd force-bdss && edm run -- python -m ci build-env && edm run -- python -m ci install && popd
 script:
     - edm run -- python -m ci install

--- a/itwm_example/mco/tests/test_weighted_mco.py
+++ b/itwm_example/mco/tests/test_weighted_mco.py
@@ -106,4 +106,4 @@ class TestWeightedMCO(TestCase, UnittestTools):
                 "force_bdss.api.Workflow.execute", return_value=kpis
             ) as mock_exec:
                 mco.run(evaluator)
-                self.assertEqual(63, mock_exec.call_count)
+                self.assertEqual(54, mock_exec.call_count)


### PR DESCRIPTION
Minor fix to unit tests.

From https://github.com/force-h2020/force-bdss/pull/353 the KPI values are now cached for an MCO using the `WeightedOptimizerEngine`.

Therefore the number of times we expect `Workflow.evaluate` to be called is reduced in the unit tests.